### PR TITLE
Lead Status #10

### DIFF
--- a/database/migrations/2021_01_01_110000_populate_statuses_table.php
+++ b/database/migrations/2021_01_01_110000_populate_statuses_table.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Roberts\Leads\Enums\LeadStatus;
+use Roberts\Leads\Models\Lead;
+use Tipoff\Statuses\Models\Status;
+
+class PopulateStatusesTable extends Migration
+{
+    public function up()
+    {
+        Status::publishStatuses(Lead::STATUS_TYPE, LeadStatus::getValues());
+    }
+}

--- a/src/Enums/LeadStatus.php
+++ b/src/Enums/LeadStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Roberts\Leads\Enums;
+
+use BenSampo\Enum\Enum;
+
+final class LeadStatus extends Enum
+{
+    const OPEN = 'Open';
+    const PARTIAL = 'Partial';
+    const RECEIVED = 'Received';
+    const VALIDATED = 'Validated';
+    const PROCESSING = 'Processing';
+    const INACTIVE = 'Inactive';
+    const CLOSED = 'Closed';
+}

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -6,7 +6,6 @@ use Assert\Assert;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 use Roberts\Leads\Enums\LeadStatus;
-use Tipoff\Statuses\Models\Status;
 use Tipoff\Statuses\Traits\HasStatuses;
 use Tipoff\Support\Models\BaseModel;
 use Tipoff\Support\Traits\HasCreator;
@@ -15,10 +14,10 @@ use Tipoff\Support\Traits\HasUpdater;
 
 class Lead extends BaseModel
 {
-    use HasCreator,
-        HasPackageFactory,
-        HasUpdater,
-        HasStatuses;
+    use HasCreator;
+    use HasPackageFactory;
+    use HasUpdater;
+    use HasStatuses;
 
     protected $guarded = [
         'id',

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -5,6 +5,8 @@ namespace Roberts\Leads\Models;
 use Assert\Assert;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
+use Roberts\Leads\Enums\LeadStatus;
+use Tipoff\Statuses\Models\Status;
 use Tipoff\Statuses\Traits\HasStatuses;
 use Tipoff\Support\Models\BaseModel;
 use Tipoff\Support\Traits\HasCreator;
@@ -28,12 +30,18 @@ class Lead extends BaseModel
         'verified_at' => 'datetime',
     ];
 
+    const STATUS_TYPE = 'lead';
+
     protected static function boot()
     {
         parent::boot();
 
         static::creating(function (Lead $lead) {
             $lead->lead_number = $lead->lead_number ?: $lead->generateLeadNumber();
+        });
+
+        static::created(function (Lead $lead) {
+            $lead->setLeadStatus(LeadStatus::OPEN);
         });
 
         static::saving(function (Lead $lead) {
@@ -50,6 +58,21 @@ class Lead extends BaseModel
         } while (static::query()->where('lead_number', $token)->count()); //check if the token already exists and if it does, try again
 
         return $token;
+    }
+
+    public function setLeadStatus(string $status)
+    {
+        return $this->setStatus($status, static::STATUS_TYPE);
+    }
+
+    public function getLeadStatus()
+    {
+        return $this->getStatus(static::STATUS_TYPE);
+    }
+
+    public function getLeadStatusHistory()
+    {
+        return $this->getStatusHistory(static::STATUS_TYPE);
     }
 
     public function business()

--- a/src/Models/Lead.php
+++ b/src/Models/Lead.php
@@ -5,6 +5,7 @@ namespace Roberts\Leads\Models;
 use Assert\Assert;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
+use Tipoff\Statuses\Traits\HasStatuses;
 use Tipoff\Support\Models\BaseModel;
 use Tipoff\Support\Traits\HasCreator;
 use Tipoff\Support\Traits\HasPackageFactory;
@@ -12,9 +13,10 @@ use Tipoff\Support\Traits\HasUpdater;
 
 class Lead extends BaseModel
 {
-    use HasCreator;
-    use HasPackageFactory;
-    use HasUpdater;
+    use HasCreator,
+        HasPackageFactory,
+        HasUpdater,
+        HasStatuses;
 
     protected $guarded = [
         'id',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,6 +8,9 @@ use Laravel\Nova\NovaCoreServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Roberts\Leads\LeadsServiceProvider;
 use Roberts\Leads\Tests\Support\Providers\NovaTestbenchServiceProvider;
+use Spatie\Permission\PermissionServiceProvider;
+use Tipoff\Authorization\AuthorizationServiceProvider;
+use Tipoff\Statuses\StatusesServiceProvider;
 use Tipoff\Support\SupportServiceProvider;
 use Tipoff\TestSupport\BaseTestCase;
 
@@ -18,9 +21,12 @@ class TestCase extends BaseTestCase
         return [
             NovaCoreServiceProvider::class,
             NovaTestbenchServiceProvider::class,
-            LeadsServiceProvider::class,
             SupportServiceProvider::class,
+            StatusesServiceProvider::class,
+            AuthorizationServiceProvider::class,
+            PermissionServiceProvider::class,
             LivewireServiceProvider::class,
+            LeadsServiceProvider::class,
         ];
     }
 }

--- a/tests/Unit/Models/LeadTest.php
+++ b/tests/Unit/Models/LeadTest.php
@@ -5,9 +5,11 @@ namespace Roberts\Leads\Tests\Unit\Models;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Carbon;
+use Roberts\Leads\Enums\LeadStatus;
 use Roberts\Leads\Models\Lead;
 use Roberts\Leads\Models\LeadBusiness;
 use Roberts\Leads\Tests\TestCase;
+use Tipoff\Statuses\Models\StatusRecord;
 
 class LeadTest extends TestCase
 {
@@ -82,5 +84,41 @@ class LeadTest extends TestCase
         LeadBusiness::factory()->create(['lead_id' => $lead->id]);
 
         $this->assertInstanceOf(LeadBusiness::class, $lead->business);
+    }
+
+    /** @test */
+    public function it_has_statuses()
+    {
+        $lead = Lead::factory()->create();
+
+        $lead->setLeadStatus(LeadStatus::PARTIAL);
+
+        $history = $lead->getLeadStatusHistory()
+            ->map(function (StatusRecord $statusRecord) {
+                return (string) $statusRecord->status;
+            })->toArray();
+
+        $this->assertEquals(
+            [LeadStatus::PARTIAL, LeadStatus::OPEN],
+            $history
+        );
+    }
+
+    /** @test */
+    public function it_sets_a_new_status()
+    {
+        $lead = Lead::factory()->create();
+
+        $lead->setLeadStatus(LeadStatus::PARTIAL);
+
+        $this->assertEquals(LeadStatus::PARTIAL, $lead->getLeadStatus());
+    }
+
+    /** @test */
+    public function it_is_associated_with_an_open_status_as_it_is_created()
+    {
+        $lead = Lead::factory()->create();
+
+        $this->assertEquals(LeadStatus::OPEN, $lead->getLeadStatus());
     }
 }


### PR DESCRIPTION
- Added `setLeadStatus`, `getLeadStatus`, `getLeadStatusHistory` method to `Lead` model
- Populate statuses table based on the values of `LeadStatus` enum
- Attached an 'open' status to new leads (new is a reserved word in php)